### PR TITLE
Prevent invalid lines from causing duplicates

### DIFF
--- a/plugin/qargs.vim
+++ b/plugin/qargs.vim
@@ -3,7 +3,11 @@ function! QuickfixFilenames()
   " Building a hash ensures we get each buffer only once
   let buffer_numbers = {}
   for quickfix_item in getqflist()
-    let buffer_numbers[quickfix_item['bufnr']] = bufname(quickfix_item['bufnr'])
+    let bufnr = quickfix_item['bufnr']
+    " Lines without files will appear as bufnr=0
+    if bufnr > 0
+      let buffer_numbers[bufnr] = bufname(bufnr)
+    endif
   endfor
   return join(map(values(buffer_numbers), 'fnameescape(v:val)'))
 endfunction


### PR DESCRIPTION
Looks like you're accepting pull requests. Maybe you want this change to fix duplicate items in the argslist?

bufnr=0 is the alternate-file and not a proper buffer number, so ignore
it. When you have lines in the quickfix without associated files, they
will have bufnr=0. Example:
    || grep: data: Is a directory